### PR TITLE
Update loss G_loss_S

### DIFF
--- a/timegan.py
+++ b/timegan.py
@@ -197,7 +197,7 @@ def timegan (ori_data, parameters):
   G_loss_U_e = tf.losses.sigmoid_cross_entropy(tf.ones_like(Y_fake_e), Y_fake_e)
     
   # 2. Supervised loss
-  G_loss_S = tf.losses.mean_squared_error(H[:,1:,:], H_hat_supervise[:,:-1,:])
+  G_loss_S = tf.losses.mean_squared_error(H_hat[:,1:,:], H_hat_supervise[:,:-1,:])
     
   # 3. Two Momments
   G_loss_V1 = tf.reduce_mean(tf.abs(tf.sqrt(tf.nn.moments(X_hat,[0])[1] + 1e-6) - tf.sqrt(tf.nn.moments(X,[0])[1] + 1e-6)))


### PR DESCRIPTION
In the supervised stage of generator training we train both the Generator and the Supervisor. G_loss_S loss only includes terms involving the supervisor, thus we must exchange the loss function from

            G_loss_S = tf.keras.losses.MSE(H[:, 1:, :], H_hat_supervise[:, 1:, :])
to 

            G_loss_S = tf.keras.losses.MSE(H_hat[:, 1:, :], H_hat_supervise[:, 1:, :])

with 

            H = encoder(X)
            # Generator
            E_hat = generator(X)
            H_hat = supervisor(E_hat)
            H_hat_supervise = supervisor(H)

since the generator is not involved in generating H but in H_hat. Please correct me if I am wrong.